### PR TITLE
Correcting "final" object print method

### DIFF
--- a/R/sa_print.R
+++ b/R/sa_print.R
@@ -170,7 +170,7 @@ print.final <- function(x, calendar, n_last_obs = frequency(x$series), print_for
   if(print_forecasts){
     cat("\nForecasts:\n")
     print(head(
-      .preformat.ts(x[[1]], calendar = calendar),
+      .preformat.ts(x[[2]], calendar = calendar),
       n_last_obs
     ))
   }


### PR DESCRIPTION
Single change in line 173, so that forecasts are displayed under the "forecast" preview object, rather than SA decomposition of the first year's data (as advised by Alain).